### PR TITLE
157589640 Cache Nutritional Values for Plan 

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ django_mobile
 django-formtools>=1.0,<1.1
 bleach
 python-mimeparse
-pillow
+pillow  
 easy-thumbnails
 django_compressor
 icalendar

--- a/wger/nutrition/models.py
+++ b/wger/nutrition/models.py
@@ -163,6 +163,18 @@ class NutritionPlan(models.Model):
             
         return result
 
+    @staticmethod
+    def get_nutritional_plans(user):
+
+        plans_dict = cache.get('nutritional_plans')
+        if not plans_dict:
+            plans_dict = {}
+            plans = NutritionPlan.objects.filter(user=user)[:150]
+            for plan in plans:
+                plans_dict["plan-{}".format(plan.id)] = plan
+                cache.set('nutritional_plans', plans_dict)
+        return plans_dict.values()
+
     def get_closest_weight_entry(self):
         '''
         Returns the closest weight entry for the nutrition plan.
@@ -696,9 +708,11 @@ def handle_cache(sender, **kwargs):
     '''
     deletes the cached data nutrition database is changed
     '''
-
+    
     model = kwargs.get('instance')
     if isinstance(model, (Meal, MealItem)):
         cache.delete(cache_mapper.get_nutrition_item(model.get_owner_object().id))
     else:
+        
         cache.delete(cache_mapper.get_nutrition_item(model.id))
+    

--- a/wger/nutrition/models.py
+++ b/wger/nutrition/models.py
@@ -32,6 +32,8 @@ from django.utils.encoding import python_2_unicode_compatible
 from django.utils.translation import ugettext_lazy as _
 from django.utils import translation
 from django.conf import settings
+from django.db.models.signals import post_save, post_delete
+from django.dispatch import receiver
 
 from wger.core.models import Language
 from wger.utils.constants import TWOPLACES
@@ -109,48 +111,54 @@ class NutritionPlan(models.Model):
         '''
         Sums the nutritional info of all items in the plan
         '''
-        use_metric = self.user.userprofile.use_metric
-        unit = 'kg' if use_metric else 'lb'
-        result = {'total': {'energy': 0,
-                            'protein': 0,
-                            'carbohydrates': 0,
-                            'carbohydrates_sugar': 0,
-                            'fat': 0,
-                            'fat_saturated': 0,
-                            'fibres': 0,
-                            'sodium': 0},
-                  'percent': {'protein': 0,
-                              'carbohydrates': 0,
-                              'fat': 0},
-                  'per_kg': {'protein': 0,
-                             'carbohydrates': 0,
-                             'fat': 0},
-                  }
 
-        # Energy
-        for meal in self.meal_set.select_related():
-            values = meal.get_nutritional_values(use_metric=use_metric)
-            for key in result['total'].keys():
-                result['total'][key] += values[key]
+        result = cache.get(cache_mapper.get_nutrition_item(self.id))
+        if not result:
+            use_metric = self.user.userprofile.use_metric
+            unit = 'kg' if use_metric else 'lb'
+            result = {'total': {'energy': 0,
+                                'protein': 0,
+                                'carbohydrates': 0,
+                                'carbohydrates_sugar': 0,
+                                'fat': 0,
+                                'fat_saturated': 0,
+                                'fibres': 0,
+                                'sodium': 0},
+                    'percent': {'protein': 0,
+                                'carbohydrates': 0,
+                                'fat': 0},
+                    'per_kg': {'protein': 0,
+                                'carbohydrates': 0,
+                                'fat': 0},
+                    }
 
-        energy = result['total']['energy']
+            # Energy
+            for meal in self.meal_set.select_related():
+                values = meal.get_nutritional_values(use_metric=use_metric)
+                for key in result['total'].keys():
+                    result['total'][key] += values[key]
 
-        # In percent
-        if energy:
-            for key in result['percent'].keys():
-                result['percent'][key] = \
-                    result['total'][key] * ENERGY_FACTOR[key][unit] / energy * 100
+            energy = result['total']['energy']
 
-        # Per body weight
-        weight_entry = self.get_closest_weight_entry()
-        if weight_entry:
-            for key in result['per_kg'].keys():
-                result['per_kg'][key] = result['total'][key] / weight_entry.weight
+            # In percent
+            if energy:
+                for key in result['percent'].keys():
+                    result['percent'][key] = \
+                        result['total'][key] * ENERGY_FACTOR[key][unit] / energy * 100
 
-        # Only 2 decimal places, anything else doesn't make sense
-        for key in result.keys():
-            for i in result[key]:
-                result[key][i] = Decimal(result[key][i]).quantize(TWOPLACES)
+            # Per body weight
+            weight_entry = self.get_closest_weight_entry()
+            if weight_entry:
+                for key in result['per_kg'].keys():
+                    result['per_kg'][key] = result['total'][key] / weight_entry.weight
+
+            # Only 2 decimal places, anything else doesn't make sense
+            for key in result.keys():
+                for i in result[key]:
+                    result[key][i] = Decimal(result[key][i]).quantize(TWOPLACES)
+
+        cache.set(cache_mapper.get_nutrition_item(self.id), result)
+        cache.close()
 
         return result
 
@@ -675,3 +683,21 @@ class MealItem(models.Model):
             nutritional_info[i] = Decimal(nutritional_info[i]).quantize(TWOPLACES)
 
         return nutritional_info
+
+
+@receiver(post_save, sender=NutritionPlan)
+@receiver(post_delete, sender=NutritionPlan)
+@receiver(post_save, sender=Meal)
+@receiver(post_delete, sender=Meal)
+@receiver(post_save, sender=MealItem)
+@receiver(post_delete, sender=MealItem)
+def handle_cache(sender, **kwargs):
+    '''
+    deletes the cached data nutrition database is changed
+    '''
+
+    model = kwargs.get('instance')
+    if isinstance(model, (Meal, MealItem)):
+        cache.delete(cache_mapper.get_nutrition_item(model.get_owner_object().id))
+    else:
+        cache.delete(cache_mapper.get_nutrition_item(model.id))

--- a/wger/nutrition/models.py
+++ b/wger/nutrition/models.py
@@ -157,9 +157,10 @@ class NutritionPlan(models.Model):
                 for i in result[key]:
                     result[key][i] = Decimal(result[key][i]).quantize(TWOPLACES)
 
-        cache.set(cache_mapper.get_nutrition_item(self.id), result)
-        cache.close()
-
+            cache.set(cache_mapper.get_nutrition_item(self.id), result)
+            cache.get(cache_mapper.get_nutrition_item(self.id))
+            cache.close()
+            
         return result
 
     def get_closest_weight_entry(self):

--- a/wger/nutrition/views/plan.py
+++ b/wger/nutrition/views/plan.py
@@ -118,14 +118,13 @@ class PlanEditView(WgerFormMixin, UpdateView):
         '''
         Send some additional data to the template
         '''
-        import timeit
+
 
         start = timeit.default_timer()
         context = super(PlanEditView, self).get_context_data(**kwargs)
         context['title'] = _(u'Edit {0}').format(self.object)
 
-        end = timeit.default_timer()
-        print(end-start,' eeeeeeeeeeedddddddddit')
+
         return context
     
 

--- a/wger/nutrition/views/plan.py
+++ b/wger/nutrition/views/plan.py
@@ -120,7 +120,6 @@ class PlanEditView(WgerFormMixin, UpdateView):
         '''
 
 
-        start = timeit.default_timer()
         context = super(PlanEditView, self).get_context_data(**kwargs)
         context['title'] = _(u'Edit {0}').format(self.object)
 

--- a/wger/nutrition/views/plan.py
+++ b/wger/nutrition/views/plan.py
@@ -99,6 +99,7 @@ class PlanDeleteView(WgerDeleteMixin, DeleteView):
         '''
         Send some additional data to the template
         '''
+       
         context = super(PlanDeleteView, self).get_context_data(**kwargs)
         context['title'] = _(u'Delete {0}?').format(self.object)
         return context
@@ -117,6 +118,7 @@ class PlanEditView(WgerFormMixin, UpdateView):
         '''
         Send some additional data to the template
         '''
+
         context = super(PlanEditView, self).get_context_data(**kwargs)
         context['title'] = _(u'Edit {0}').format(self.object)
         return context
@@ -126,6 +128,7 @@ def view(request, id):
     '''
     Show the nutrition plan with the given ID
     '''
+
     template_data = {}
 
     plan = get_object_or_404(NutritionPlan, pk=id)

--- a/wger/nutrition/views/plan.py
+++ b/wger/nutrition/views/plan.py
@@ -64,7 +64,7 @@ def overview(request):
     template_data = {}
     template_data.update(csrf(request))
 
-    plans = NutritionPlan.objects.filter(user=request.user)
+    plans = NutritionPlan.get_nutritional_plans(user=request.user)
     template_data['plans'] = plans
 
     return render(request, 'plan/overview.html', template_data)
@@ -118,11 +118,16 @@ class PlanEditView(WgerFormMixin, UpdateView):
         '''
         Send some additional data to the template
         '''
+        import timeit
 
+        start = timeit.default_timer()
         context = super(PlanEditView, self).get_context_data(**kwargs)
         context['title'] = _(u'Edit {0}').format(self.object)
-        return context
 
+        end = timeit.default_timer()
+        print(end-start,' eeeeeeeeeeedddddddddit')
+        return context
+    
 
 def view(request, id):
     '''

--- a/wger/utils/cache.py
+++ b/wger/utils/cache.py
@@ -67,6 +67,7 @@ class CacheKeyMapper(object):
     INGREDIENT_CACHE_KEY = 'ingredient-{0}'
     WORKOUT_CANONICAL_REPRESENTATION = 'workout-canonical-representation-{0}'
     WORKOUT_LOG_LIST = 'workout-log-hash-{0}'
+    NUTRITION_CACHE_KEY = 'nutrition-{0}'
 
     def get_pk(self, param):
         '''
@@ -114,5 +115,10 @@ class CacheKeyMapper(object):
         Return the workout canonical representation
         '''
         return self.WORKOUT_LOG_LIST.format(hash_value)
+
+    def get_nutrition_item(self, param):
+        '''Returns nutrional cahce key'''
+        
+        return self.NUTRITION_CACHE_KEY.format(self.get_pk(param))
 
 cache_mapper = CacheKeyMapper()


### PR DESCRIPTION
#### What does this PR do?
* Implement cache on nutritional plan
#### Description of Task to be completed?
If a user has many plans (approx. more than 25), the overview renders slowly as too many DB-queries are fired just to calculate the total calories.
cache the nutritional_info dictionary in NutritionPlans
add signals that delete the cache key everytime a NutritionPlan, Meal and MealItem is added, edited or deleted.
#### How should this be manually tested?
This can be tested by adding more than 100 plans and checking the load time taken when the overview page is rendered.
#### What are the relevant pivotal tracker stories?
#157589640