### PR TITLE
#157589645 Reset Muscle Cache on Delete

### DIFF
--- a/wger/exercises/signals.py
+++ b/wger/exercises/signals.py
@@ -18,11 +18,19 @@
 from django.db.models.signals import pre_save
 from django.db.models.signals import post_delete
 from django.dispatch import receiver
+from django.core.cache import cache
 from easy_thumbnails.files import get_thumbnailer
 from easy_thumbnails.signal_handlers import generate_aliases
 from easy_thumbnails.signals import saved_file
 
-from wger.exercises.models import ExerciseImage
+from wger.exercises.models import ExerciseImage, Muscle
+
+@receiver(post_delete, sender=Muscle)
+def reset_cache_on_delete_muscle(sender, instance, **kwargs):
+    '''
+    Resets the cache after muscle is deleted.
+    '''
+    cache.clear()
 
 
 @receiver(post_delete, sender=ExerciseImage)


### PR DESCRIPTION
### What does this PR do?

- Resets the cache after a muscle is deleted.

### Description of Task to be completed?

- The cache should be reset after a muscle has been deleted such that the deleted muscle in not visible from the exercises page.

#### How should this be manually tested?

- Log in to the application as an admin, visit the muscle menu under the exercise tab https://ravens-staging.herokuapp.com/en/exercise/muscle/admin-overview/
- Click on the add muscle button and add a muscle name. 
- Visit the add exercise tab and add a new exercise focusing on the new muscle added. 
- Go back to the muscles menu and delete the recently added muscle and verify that the muscle no-longer included under the exercise menu. 

### Any background context you want to provide?

- Initially, after deleting a muscle, it still appeared under the exercise description associated with deleted muscle. This was caused by a failure to reset muscle cache on delete.

### What are the relevant pivotal tracker stories?

#157589645
