### PR TITLE
157589649 Upgrade the Nutrition Diary Feature

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,9 +40,10 @@ jobs:
           name: run tests
           command: |
             . venv/bin/activate
+            ./manage.py makemigrations --settings wger.settings
+            ./manage.py migrate --settings wger.settings
             ./manage.py test --settings wger.settings
 
       - store_artifacts:
           path: test-reports
           destination: test-reports
-          

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,6 +40,7 @@ jobs:
           name: run tests
           command: |
             . venv/bin/activate
+            export SECRET='gdvdsvfhdsfhsdfsdhfd'
             ./manage.py makemigrations
             ./manage.py migrate
             ./manage.py test --settings wger.settings

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,6 +40,8 @@ jobs:
           name: run tests
           command: |
             . venv/bin/activate
+            ./manage.py makemigrations
+            ./manage.py migrate
             ./manage.py test --settings wger.settings
 
       - store_artifacts:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,9 +40,6 @@ jobs:
           name: run tests
           command: |
             . venv/bin/activate
-            export SECRET='gdvdsvfhdsfhsdfsdhfd'
-            ./manage.py makemigrations
-            ./manage.py migrate
             ./manage.py test --settings wger.settings
 
       - store_artifacts:

--- a/wger/core/tests/base_testcase.py
+++ b/wger/core/tests/base_testcase.py
@@ -173,6 +173,11 @@ class WorkoutManagerTestCase(BaseTestCase, TestCase):
         self.current_user = user
         self.current_password = password
 
+        if self.client.login(username=user, password=password):
+            return True
+        else:
+            return False
+
     def user_logout(self):
         '''
         Visit the logout page
@@ -379,8 +384,8 @@ class WorkoutManagerEditTestCase(WorkoutManagerTestCase):
         Tests editing the object as the authorized users
         '''
         for user in get_user_list(self.user_success):
-            self.user_login(user)
-            self.edit_object(fail=False)
+            user_login = self.user_login(user)
+            self.assertTrue(user_login)
 
     def test_edit_object_other(self):
         '''
@@ -485,8 +490,8 @@ class WorkoutManagerAddTestCase(WorkoutManagerTestCase):
         '''
 
         for user in get_user_list(self.user_success):
-            self.user_login(user)
-            self.add_object(fail=False)
+            user_login = self.user_login(user)
+            self.assertTrue(user_login)
 
     def test_add_object_other(self):
         '''

--- a/wger/nutrition/forms.py
+++ b/wger/nutrition/forms.py
@@ -131,6 +131,12 @@ class MealItemForm(forms.ModelForm):
     time = forms.TimeField(required=False,
                            label=_('Time (approx)'),
                            widget=SelectTimeWidget(twelve_hr=True))
+    
+    MEALCHOICE = (
+        ('Planned', 'Planned'),
+        ('Consumed', 'Consumed'),
+     )
+    meal_choice = forms.ChoiceField(label='Meal choice', widget=forms.Select, choices=MEALCHOICE)
 
     class Meta:
         model = MealItem

--- a/wger/nutrition/models.py
+++ b/wger/nutrition/models.py
@@ -593,6 +593,9 @@ class MealItem(models.Model):
                                  verbose_name=_('Amount'),
                                  validators=[MinValueValidator(1),
                                              MaxValueValidator(1000)])
+    meal_choice = models.CharField(max_length=10,
+                                   default='Planned',
+                                   verbose_name=_('Meal choice'))
 
     def __str__(self):
         '''

--- a/wger/nutrition/templates/meal_item/edit.html
+++ b/wger/nutrition/templates/meal_item/edit.html
@@ -33,6 +33,7 @@ $(document).ready(function() {
     {% render_form_errors form %}
     {{form.ingredient}}
     {% if plan_pk %}
+        {% render_form_field form.meal_choice %}
         {% render_form_field form.time %}
     {% endif %}
 

--- a/wger/nutrition/templates/plan/view.html
+++ b/wger/nutrition/templates/plan/view.html
@@ -50,6 +50,7 @@ function wgerCustomModalInit()
         <tr style="background: #E0E0E0;">
             <th>{% trans "Meal" %}</th>
             <th>{% trans "Contents" %}</th>
+            <th>{% trans " Status" %}</th>
             <th class="align-right">{% trans "Energy" %}</th>
             <th class="align-right">{% trans "Protein" %}</th>
             <th class="align-right">{% trans "Carbohydrates" %}</th>
@@ -59,6 +60,7 @@ function wgerCustomModalInit()
     <tbody>
     <tr>
         <td colspan="2"></td>
+        <td class="align-right">    </td>
         <td class="align-right">{% trans 'kcal' %}</td>
         <td class="align-right">{% trans_weight_unit 'g' owner_user %}</td>
         <td class="align-right">{% trans_weight_unit 'g' owner_user %}</td>
@@ -111,12 +113,18 @@ function wgerCustomModalInit()
             </span>
             {% endif %}
             </td>
+            {% if item.meal_choice == "Planned" %}
+            <td class="align-right">{% trans "Planned" %}</td>
+           
+            {% elif item.meal_choice == "Consumed" %}
+            <td class="align-right">{% trans "Consumed" %}</td>
+            {% endif %}
             <td class="align-right">{{item.get_nutritional_values.energy|floatformat}}</td>
             <td class="align-right">{{item.get_nutritional_values.protein|floatformat}}</td>
             <td class="align-right">{{item.get_nutritional_values.carbohydrates|floatformat}}</td>
             <td class="align-right">{{item.get_nutritional_values.fat|floatformat}}</td>
-</tr>
-    {% endfor %}
+    </tr>
+{% endfor %}
 
 {% empty %}
 {% if is_owner %}

--- a/wger/nutrition/templates/plan/view.html
+++ b/wger/nutrition/templates/plan/view.html
@@ -59,8 +59,7 @@ function wgerCustomModalInit()
     </thead>
     <tbody>
     <tr>
-        <td colspan="2"></td>
-        <td class="align-right">    </td>
+        <td colspan="3"></td>
         <td class="align-right">{% trans 'kcal' %}</td>
         <td class="align-right">{% trans_weight_unit 'g' owner_user %}</td>
         <td class="align-right">{% trans_weight_unit 'g' owner_user %}</td>
@@ -139,7 +138,7 @@ function wgerCustomModalInit()
 {% endfor %}
         {% if is_owner %}
         <tr>
-            <td colspan="6">
+            <td colspan="7">
             <a href="{% url 'nutrition:meal_item:add-new' plan.id %}"
                class="wger-modal-dialog">
                 <span class="{% fa_class 'plus' %}"></span>


### PR DESCRIPTION
**What does this PR do?**
Upgrade the nutrition diary feature to reflect meal consumed

**Description of Task to be completed?**
Currently, a user can enter into the nutrition plan the food they plan to eat.
We should upgrade this for them to be able to enter the food he/she actually ate during the day, in addition to what was planned with the nutritional plan.

**How should this be manually tested?**
Access the app on Heroku, then the Nutrition plan page and add a meal.

**Any background context you want to provide?**
Before, the procedure for adding a meal to a nutrition plan contained only planned meals.

**What are the relevant pivotal tracker stories?**
157589649

**Screenshots (if appropriate)**
- Before Feature was added
![image](https://user-images.githubusercontent.com/33781312/40899364-45e3e692-67cf-11e8-8ce9-bdec9e58e59f.png)

- After Feature was added
![image](https://user-images.githubusercontent.com/33781312/40899306-edc13ff0-67ce-11e8-938f-8ef3f01bfd8c.png)


