### PR TITLE
#157589647 Create Foreign Key in Workout Session

### DIFF
--- a/wger/manager/models.py
+++ b/wger/manager/models.py
@@ -808,6 +808,11 @@ class WorkoutSession(models.Model):
     The date the workout session was performed
     '''
 
+    workout_log = models.ForeignKey(WorkoutLog, verbose_name=_('WorkoutLog'), null=True, blank=True)
+    '''
+    The workout log the session belongs to
+    '''
+
     notes = models.TextField(verbose_name=_('Notes'),
                              null=True,
                              blank=True,

--- a/wger/manager/tests/test_weight_log.py
+++ b/wger/manager/tests/test_weight_log.py
@@ -263,6 +263,7 @@ class WeightlogTestCase(WorkoutManagerTestCase):
         session1 = WorkoutSession()
         session1.user = user1
         session1.workout = workout1
+        session1.workout_log = l
         session1.notes = 'Something here'
         session1.impression = '3'
         session1.date = datetime.date(2014, 1, 5)


### PR DESCRIPTION
**What does this PR do?**
It creates a real foreign key in workout sessions.

**Description of Task to be completed?**
Add a real foreign key in the workout sessions.

**How should this be manually tested?**
A user can link a session to a log using the foreign key.

**Any background context you want to provide?**
Right now the workout logs and the workout session are only linked through the date (for sessions this value is unique and enforced by the DB).

**What are the relevant pivotal tracker stories?**
#157589647

