### PR TITLE
Ft exercise info api 157589641

### DIFF
--- a/wger/exercises/api/serializers.py
+++ b/wger/exercises/api/serializers.py
@@ -29,6 +29,8 @@ class ExerciseSerializer(serializers.ModelSerializer):
     '''
     Exercise serializer
     '''
+    image = serializers.Field(source='main_image')
+    description = serializers.ReadOnlyField(source='description_clean')
     class Meta:
         model = Exercise
         fields = ('category',
@@ -41,7 +43,8 @@ class ExerciseSerializer(serializers.ModelSerializer):
                  'name',
                  'equipment',
                  'license',
-                 'license_author')
+                 'license_author',
+                 'image')
 
 
 class EquipmentSerializer(serializers.ModelSerializer):

--- a/wger/exercises/api/serializers.py
+++ b/wger/exercises/api/serializers.py
@@ -31,6 +31,17 @@ class ExerciseSerializer(serializers.ModelSerializer):
     '''
     class Meta:
         model = Exercise
+        fields = ('category',
+                 'creation_date',
+                 'description',
+                 'language',
+                 'muscles',
+                 'muscles_secondary',
+                 'status',
+                 'name',
+                 'equipment',
+                 'license',
+                 'license_author')
 
 
 class EquipmentSerializer(serializers.ModelSerializer):

--- a/wger/exercises/api/views.py
+++ b/wger/exercises/api/views.py
@@ -54,17 +54,6 @@ class ExerciseViewSet(viewsets.ModelViewSet):
     serializer_class = ExerciseSerializer
     permission_classes = (IsAuthenticatedOrReadOnly, CreateOnlyPermission)
     ordering_fields = '__all__'
-    filter_fields = ('category',
-                     'creation_date',
-                     'description',
-                     'language',
-                     'muscles',
-                     'muscles_secondary',
-                     'status',
-                     'name',
-                     'equipment',
-                     'license',
-                     'license_author')
 
     def perform_create(self, serializer):
         '''

--- a/wger/urls.py
+++ b/wger/urls.py
@@ -168,6 +168,7 @@ urlpatterns = i18n_patterns(url(r'^admin/', include(admin.site.urls)),
 
 #
 # URLs without language prefix
+print(router.urls)
 #
 urlpatterns += [
     url(r'^robots\.txt$', TextTemplateView.as_view(template_name="robots.txt"),
@@ -181,7 +182,8 @@ urlpatterns += [
     url(r'^api/v2/exercise/search/$', exercises_api_views.search,
         name='exercise-search'),
     url(r'^api/v2/ingredient/search/$', nutrition_api_views.search,
-        name='ingredient-search'), url(r'^api/v2/', include(router.urls)), ]
+        name='ingredient-search'),
+    url(r'^api/v2/', include(router.urls)), ]
 
 #
 # URL for user uploaded files, served like this during development only

--- a/wger/urls.py
+++ b/wger/urls.py
@@ -168,7 +168,6 @@ urlpatterns = i18n_patterns(url(r'^admin/', include(admin.site.urls)),
 
 #
 # URLs without language prefix
-print(router.urls)
 #
 urlpatterns += [
     url(r'^robots\.txt$', TextTemplateView.as_view(template_name="robots.txt"),


### PR DESCRIPTION
#### What does this PR do?
Adds ability to collect all information of an exercise in `JSON` format for API calls.

#### Description of Task to be completed?
Add a read only API ability to retrieve an exercises information using its `id`. This information contains the image of the exercise if available, description etc.

#### How should this be manually tested?
- Clone repo and run server locally
- Use Postman or Curl to send a `GET` request to `http://127.0.0.1:8000/api/v2/exercise/<id>/` whereby `<id>` represents an the id of the exercise as an integer

#### Any background context you want to provide?
This task uses `django-rest-framework`

#### What are the relevant pivotal tracker stories?
#157589641