### PR TITLE
#157589655 Add Macrocycle, Mesocycle, and Microcycle support

### DIFF
--- a/wger/core/fixtures/days_of_week.json
+++ b/wger/core/fixtures/days_of_week.json
@@ -3,49 +3,200 @@
         "pk": 1, 
         "model": "core.daysofweek", 
         "fields": {
-            "day_of_week": "Monday"
+            "day_of_week": "Monday",
+            "plan_type": "day"
         }
     }, 
     {
         "pk": 2, 
         "model": "core.daysofweek", 
         "fields": {
-            "day_of_week": "Tuesday"
+            "day_of_week": "Tuesday",
+            "plan_type": "day"
         }
     }, 
     {
         "pk": 3, 
         "model": "core.daysofweek", 
         "fields": {
-            "day_of_week": "Wednesday"
+            "day_of_week": "Wednesday",
+            "plan_type": "day"
         }
     }, 
     {
         "pk": 4, 
         "model": "core.daysofweek", 
         "fields": {
-            "day_of_week": "Thursday"
+            "day_of_week": "Thursday",
+            "plan_type": "day"
         }
     }, 
     {
         "pk": 5, 
         "model": "core.daysofweek", 
         "fields": {
-            "day_of_week": "Friday"
+            "day_of_week": "Friday",
+            "plan_type": "day"
         }
     }, 
     {
         "pk": 6, 
         "model": "core.daysofweek", 
         "fields": {
-            "day_of_week": "Saturday"
+            "day_of_week": "Saturday",
+            "plan_type": "day"
         }
     }, 
     {
         "pk": 7, 
         "model": "core.daysofweek", 
         "fields": {
-            "day_of_week": "Sunday"
+            "day_of_week": "Sunday",
+            "plan_type": "day"
+        }
+    },
+    {
+        "pk": 8, 
+        "model": "core.daysofweek", 
+        "fields": {
+            "day_of_week": "Week 1",
+            "plan_type": "week"
+        }
+    }, 
+    {
+        "pk": 9, 
+        "model": "core.daysofweek", 
+        "fields": {
+            "day_of_week": "Week 2",
+            "plan_type": "week"
+        }
+    }, 
+    {
+        "pk": 10, 
+        "model": "core.daysofweek", 
+        "fields": {
+            "day_of_week": "Week 3",
+            "plan_type": "week"
+        }
+    }, 
+    {
+        "pk": 11, 
+        "model": "core.daysofweek", 
+        "fields": {
+            "day_of_week": "Week 4",
+            "plan_type": "week"
+        }
+    }, 
+    {
+        "pk": 12, 
+        "model": "core.daysofweek", 
+        "fields": {
+            "day_of_week": "Week 5",
+            "plan_type": "week"
+        }
+    }, 
+    {
+        "pk": 13, 
+        "model": "core.daysofweek", 
+        "fields": {
+            "day_of_week": "Week 6",
+            "plan_type": "week"
+        }
+    }, 
+    {
+        "pk": 14, 
+        "model": "core.daysofweek", 
+        "fields": {
+            "day_of_week": "January",
+            "plan_type": "month"
+        }
+    }, 
+    {
+        "pk": 15, 
+        "model": "core.daysofweek", 
+        "fields": {
+            "day_of_week": "February",
+            "plan_type": "month"
+        }
+    }, 
+    {
+        "pk": 16, 
+        "model": "core.daysofweek", 
+        "fields": {
+            "day_of_week": "March",
+            "plan_type": "month"
+        }
+    }, 
+    {
+        "pk": 17, 
+        "model": "core.daysofweek", 
+        "fields": {
+            "day_of_week": "April",
+            "plan_type": "month"
+        }
+    }, 
+    {
+        "pk": 18, 
+        "model": "core.daysofweek", 
+        "fields": {
+            "day_of_week": "May",
+            "plan_type": "month"
+        }
+    }, 
+    {
+        "pk": 19, 
+        "model": "core.daysofweek", 
+        "fields": {
+            "day_of_week": "June",
+            "plan_type": "month"
+        }
+    }, 
+    {
+        "pk": 20, 
+        "model": "core.daysofweek", 
+        "fields": {
+            "day_of_week": "July",
+            "plan_type": "month"
+        }
+    }, 
+    {
+        "pk": 21, 
+        "model": "core.daysofweek", 
+        "fields": {
+            "day_of_week": "August",
+            "plan_type": "month"
+        }
+    }, 
+    {
+        "pk": 22, 
+        "model": "core.daysofweek", 
+        "fields": {
+            "day_of_week": "September",
+            "plan_type": "month"
+        }
+    }, 
+    {
+        "pk": 23, 
+        "model": "core.daysofweek", 
+        "fields": {
+            "day_of_week": "October",
+            "plan_type": "month"
+        }
+    }, 
+    {
+        "pk": 24, 
+        "model": "core.daysofweek", 
+        "fields": {
+            "day_of_week": "November",
+            "plan_type": "month"
+        }
+    }, 
+    {
+        "pk": 25, 
+        "model": "core.daysofweek", 
+        "fields": {
+            "day_of_week": "December",
+            "plan_type": "month"
         }
     }
 ]

--- a/wger/core/models.py
+++ b/wger/core/models.py
@@ -509,6 +509,8 @@ class DaysOfWeek(models.Model):
 
     day_of_week = models.CharField(max_length=9,
                                    verbose_name=_('Day of the week'))
+    
+    plan_type = models.CharField(max_length=9, null=True, blank=True)
 
     class Meta:
         '''

--- a/wger/core/templates/tags/render_day.html
+++ b/wger/core/templates/tags/render_day.html
@@ -124,7 +124,14 @@ $(document).ready(function() {
                     <a href="{% url 'manager:set:add' day.obj.id %}"
                        class="wger-modal-dialog btn btn-default btn-block wger-modal-dialog">
                        {% trans "No exercises selected for this day." %}
-                       {% trans "Add one now." %}
+                       {% if "Microcycle" in day.obj.training.cycle %}
+                            {% trans "No exercises selected for this day." %}
+                       {% elif "Mesocycle" in day.obj.training.cycle %}
+                            {% trans "No exercises selected for this week." %}
+                        {% elif "Macrocycle" in day.obj.training.cycle %}
+                            {% trans "No exercises selected for this month." %}
+                        {% endif %}
+                        {% trans "Add one now." %}
                     </a>
             </td>
         </tr>
@@ -134,7 +141,15 @@ $(document).ready(function() {
         <tr>
             <td colspan="2">
                 <a href="{% url 'manager:set:add' day.obj.id %}"
-                   class="wger-modal-dialog">{% trans "Add exercises to this workout day" %}</a>
+                   class="wger-modal-dialog">
+                   {% if 'Microcycle' in day.obj.training.cycle %}
+                       {% trans "Add exercises to this workout day" %}
+                    {% elif 'Mesocycle' in day.obj.training.cycle %}
+                        {% trans "Add exercises to this workout week" %}
+                    {% elif 'Macrocycle' in day.obj.training.cycle %}
+                        {% trans "Add exercises to this workout month" %}
+                    {% endif %}
+                </a>
             </td>
         </tr>
         {% endif %}

--- a/wger/manager/models.py
+++ b/wger/manager/models.py
@@ -44,6 +44,12 @@ from wger.utils.fields import Html5DateField
 
 logger = logging.getLogger(__name__)
 
+CYCLE_CHOICES = [
+        ('Microcycle', 'Microcycle - Up to one week'),
+        ('Mesocycle', 'Mesocycle - Two to six weeks'),
+        ('Macrocycle', 'Macrocycle - Up to one year')
+    ]
+
 
 #
 # Classes
@@ -67,6 +73,8 @@ class Workout(models.Model):
                                help_text=_("A short description or goal of the workout. For "
                                            "example 'Focus on back' or 'Week 1 of program xy'."))
     user = models.ForeignKey(User, verbose_name=_('User'))
+
+    cycle = models.CharField(max_length=10, choices=CYCLE_CHOICES)
 
     def get_absolute_url(self):
         '''

--- a/wger/manager/models.py
+++ b/wger/manager/models.py
@@ -47,7 +47,8 @@ logger = logging.getLogger(__name__)
 CYCLE_CHOICES = [
         ('Microcycle', 'Microcycle - Up to one week'),
         ('Mesocycle', 'Mesocycle - Two to six weeks'),
-        ('Macrocycle', 'Macrocycle - Up to one year')
+        ('Macrocycle', 'Macrocycle - Up to one year'),
+        ('None','None Selected')
     ]
 
 
@@ -74,7 +75,7 @@ class Workout(models.Model):
                                            "example 'Focus on back' or 'Week 1 of program xy'."))
     user = models.ForeignKey(User, verbose_name=_('User'))
 
-    cycle = models.CharField(max_length=10, choices=CYCLE_CHOICES)
+    cycle = models.CharField(max_length=10, choices=CYCLE_CHOICES, default='None')
 
     def get_absolute_url(self):
         '''

--- a/wger/manager/templates/schedule/overview.html
+++ b/wger/manager/templates/schedule/overview.html
@@ -40,6 +40,13 @@ succession.{% endblocktrans %}</p>
 before jumping to the next. It is also possible to create a loop, so you
 always do the same workouts in succession, e.g. A > B > C > A > B > C and so on.{% endblocktrans %}</p>
 
+<p>{% blocktrans %}You can also periodize your workouts.Periodization is the systematic planning 
+    of athletic or physical training.[1] The aim is to reach the best possible performance 
+    in the most important competition of the year. Periodization divides the year round condition program 
+    into phases of training which focus on different goals. Available cycles are
+    <strong>Microcycle(1 week), Mesocycle(2-6 Weeks) and Macrocycle(1 year)</strong>{% endblocktrans %}
+</p>
+
 <p>{% blocktrans %}The currently active schedule will remain active (and be
 shown e.g. in your dashboard) till it reaches the last workout or till you
 deactivate it, if it is a loop.{% endblocktrans %}</p>

--- a/wger/manager/templates/schedule/view.html
+++ b/wger/manager/templates/schedule/view.html
@@ -133,6 +133,7 @@
                 {% if active_workout == step %}
                 &nbsp;<span class="label label-info">{% trans "active" %}</span>
                 {% endif  %}
+                <span class="label label-success">{% trans step.workout.cycle %}</span>
             </td>
             <td>
                 {{ step.duration }}
@@ -188,6 +189,7 @@
                 {% if active_workout == step %}
                     <span class="label label-info">{% trans "active" %}</span>
                 {% endif  %}
+                <span class="label label-success">{% trans step.workout.cycle %}</span>
             </div>
             <div class="panel-body">
                 <span>{{step_dates.0}} <br> {{step_dates.1}}</span>

--- a/wger/manager/templates/workout/overview.html
+++ b/wger/manager/templates/workout/overview.html
@@ -12,9 +12,12 @@
                 <span class="glyphicon glyphicon-chevron-right pull-right"></span>
 
                 {% if workout == current_workout %}
-                <span class="badge">
+                <span class="badge" >
                     <em>{% trans "active" %}</em>
                 </span>
+                <span class="badge">
+                        <em>{% trans workout.cycle %}</em>
+                    </span>
                 {% endif %}
 
                 <h4 class="list-group-item-heading">{{ workout }}</h4>

--- a/wger/manager/templates/workout/view.html
+++ b/wger/manager/templates/workout/view.html
@@ -70,7 +70,7 @@ $(document).ready(function() {
     </div>
 {% empty %}
     {% if is_owner %}
-        {% if not workout.cycle %}
+        {% if "None" in workout.cycle %}
         <p>
             <a href="{% url 'manager:workout:edit' workout.id %}" class="wger-modal-dialog btn btn-default btn-block">
             {% trans "Please set a cycle and optionally a comment for this workout" %}

--- a/wger/manager/templates/workout/view.html
+++ b/wger/manager/templates/workout/view.html
@@ -54,7 +54,13 @@ $(document).ready(function() {
 
 {% if workout.comment %}
 <p>
-    <strong>{% trans "Goal" %}:</strong> {{workout.comment}}
+    <strong>{% trans "Description" %}:</strong> {{workout.comment}}
+</p>
+{% endif %}
+
+{% if workout.cycle %}
+<p>
+    <strong>{% trans "Cycle" %}:</strong> {{workout.cycle}}
 </p>
 {% endif %}
 
@@ -64,18 +70,42 @@ $(document).ready(function() {
     </div>
 {% empty %}
     {% if is_owner %}
+        {% if not workout.cycle %}
         <p>
-            <a href="{% url 'manager:day:add' workout.id %}" class="wger-modal-dialog btn btn-default btn-block">
-            {% trans "No days for this workout." %}
-            {% trans "Add training day" %}
+            <a href="{% url 'manager:workout:edit' workout.id %}" class="wger-modal-dialog btn btn-default btn-block">
+            {% trans "Please set a cycle and optionally a comment for this workout" %}
             </a>
         </p>
+        {% else %}
+        <p>
+            <a href="{% url 'manager:day:add' workout.id %}" class="wger-modal-dialog btn btn-default btn-block">
+            {% if "Microcycle" in workout.cycle  %}
+                {% trans "No days for this workout." %}
+                {% trans "Add training day(s)" %}
+            {% elif "Mesocycle" in workout.cycle  %}
+                {% trans "No weeks for this workout." %}
+                {% trans "Add training week(s)" %}
+            {% elif "Macrocycle" in workout.cycle  %}
+                {% trans "No months for this workout." %}
+                {% trans "Add training month(s)" %}
+            {% endif %}
+            </a>
+        </p>
+    {% endif %}
     {% endif %}
 {% endfor %}
 
 {% if is_owner %}
 <p>
-    <a href="{% url 'manager:day:add' workout.id %}" class="wger-modal-dialog">{% trans "Add training day" %}</a>
+    <a href="{% url 'manager:day:add' workout.id %}" class="wger-modal-dialog">
+        {% if "Microcycle" in workout.cycle  %}
+            {% trans "Add training day" %}
+        {% elif "Mesocycle" in workout.cycle  %}
+            {% trans "Add training week" %}
+        {% elif "Macrocycle" in workout.cycle  %}
+            {% trans "Add training month" %}
+        {% endif %}
+    </a>
     |
     <a id="exercise-comments-toggle" href="{% url 'core:user:preferences' %}">{% trans "Show/Hide exercise comments" %}</a>
 </p>
@@ -207,7 +237,7 @@ an appointment for each training day with the appropriate exercises.{% endblockt
 </div>
 {% endblock %}
 
-
+x
 
 {#         #}
 {# Options #}

--- a/wger/manager/views/day.py
+++ b/wger/manager/views/day.py
@@ -87,6 +87,16 @@ class DayEditView(DayView, UpdateView):
     # Send some additional data to the template
     def get_context_data(self, **kwargs):
         context = super(DayEditView, self).get_context_data(**kwargs)
+        workout = Day.objects.get(pk=self.kwargs['pk']).training
+        if 'Microcycle' in workout.cycle:
+            context['form'].fields['day'].label = 'Day'
+            context['form'].fields['day'].queryset = DaysOfWeek.objects.filter(plan_type='day')
+        elif 'Mesocycle' in workout.cycle:
+            context['form'].fields['day'].label = 'Week'
+            context['form'].fields['day'].queryset = DaysOfWeek.objects.filter(plan_type='week')
+        elif 'Macrocycle' in workout.cycle:
+            context['form'].fields['day'].label = 'Month'
+            context['form'].fields['day'].queryset = DaysOfWeek.objects.filter(plan_type='month')
         context['title'] = _(u'Edit {0}').format(self.object)
         return context
 
@@ -96,7 +106,6 @@ class DayCreateView(DayView, CreateView):
     Generic view to add a new exercise day
     '''
 
-    title = ugettext_lazy('Add workout day')
     owner_object = {'pk': 'workout_pk', 'class': Workout}
 
     def form_valid(self, form):
@@ -108,7 +117,40 @@ class DayCreateView(DayView, CreateView):
 
     # Send some additional data to the template
     def get_context_data(self, **kwargs):
+        workout = Workout.objects.get(pk=self.kwargs['workout_pk'])
+        if 'Microcycle' in workout.cycle:
+            DayCreateView.title = _('Add workout day(s)')
+        elif 'Mesocycle' in workout.cycle:
+            DayCreateView.title = _('Add workout week(s)')
+        elif 'Macrocycle' in workout.cycle:
+            DayCreateView.title = _('Add workout month(s)')
         context = super(DayCreateView, self).get_context_data(**kwargs)
+        already_selected_option_names = []
+        if workout.canonical_representation['day_list']:
+            for canonical_representation in workout.canonical_representation['day_list']:
+                for option in canonical_representation['days_of_week']['day_list']:
+                    already_selected_option_names.append(option.day_of_week)
+        if 'Microcycle' in workout.cycle:
+            context['form'].fields['day'].label = 'Day'
+            context['form'].fields['description'].help_text = \
+                _('A description of what is done on this day (e.g. "Pull day") '
+                  ' what body parts are trained (e.g. "Arms and abs")')
+            context['form'].fields['day'].queryset = DaysOfWeek.objects.filter(
+                plan_type='day').exclude(day_of_week__in=already_selected_option_names)
+        elif 'Mesocycle' in workout.cycle:
+            context['form'].fields['description'].help_text = \
+                _('A description of what is done on this week (e.g. '
+                  '"Pull week") or what body parts are trained (e.g. "Arms and abs")')
+            context['form'].fields['day'].label = 'Week'
+            context['form'].fields['day'].queryset = DaysOfWeek.objects.filter(
+                plan_type='week').exclude(day_of_week__in=already_selected_option_names)
+        elif 'Macrocycle' in workout.cycle:
+            context['form'].fields['day'].label = 'Month'
+            context['form'].fields['description'].help_text = \
+                _('A description of what is done on this month (e.g. '
+                  '"Pull month") or what body parts are trained (e.g. "Arms and abs")')
+            context['form'].fields['day'].queryset = DaysOfWeek.objects.filter(
+                plan_type='month').exclude(day_of_week__in=already_selected_option_names)
         context['form_action'] = reverse('manager:day:add',
                                          kwargs={'workout_pk': self.kwargs['workout_pk']})
         return context


### PR DESCRIPTION
**What does this PR do?**
Add support for macrocycle(annual plan), mesocycle(2-6 weeks) and microcycle (1 week)

**Description of Task to be completed?**
Add support for Macrocycle, Mesocycle, and Microcycle.

Macro is an annual plan, meso is phase of training with a duration of between 2-6 weeks and micro is instead only a week.
This is needed for sports periodization ( powerlifting, weightlifting, strongman, etc ) or at least to create a fitness program drafted on more than only one week.

Added badges for the various cycles.

**How should this be manually tested?**
- Login into your account.
- Click  the `Workouts` drop-down menu then the `workouts` option
- Click `Add workouts` button
- Click the  `Please set a cycle and comment for the cycle` and a form will appear
- After filling the form you will be prompted to create a plan depending on cycle you chose.

**What are the relevant pivotal tracker stories?**
157589655

**Screenshots**
_After clicking `Add workout`_

<img width="1279" alt="screen shot 2018-06-07 at 19 06 05" src="https://user-images.githubusercontent.com/16057093/41111900-0892dcb2-6a86-11e8-9092-878aa9668051.png">

<img width="1280" alt="screen shot 2018-06-07 at 19 08 40" src="https://user-images.githubusercontent.com/16057093/41111978-449cf882-6a86-11e8-9318-487402aa342d.png">

_Sample Training plan_

<img width="1280" alt="screen shot 2018-06-07 at 19 10 26" src="https://user-images.githubusercontent.com/16057093/41112045-8284b8ce-6a86-11e8-886f-fb131493db0c.png">

_Workout Schedule_

<img width="1276" alt="screen shot 2018-06-07 at 19 03 15" src="https://user-images.githubusercontent.com/16057093/41111771-b173fc86-6a85-11e8-9108-11fc19cd18bf.png">
