### PR TITLE
#157589646 Make Translations of Exercises and Ingredients Easier

### DIFF
--- a/wger/exercises/templates/exercise/overview.html
+++ b/wger/exercises/templates/exercise/overview.html
@@ -8,7 +8,22 @@
 <!--
         Title
 -->
-{% block title %}{% trans "Exercises" %}{% endblock %}
+{% block title %}{% trans "Exercises" %}
+
+<div class="btn-group" style="float:right;">
+    <button type="button" class="btn btn-primary dropdown-toggle btn-xs" data-toggle="dropdown">
+            {% trans "Filter by language" %}  <span class="caret"></span>
+    </button>
+    <ul class="dropdown-menu" role="menu">
+        <li><a href={% url 'exercise:exercise:overview' %}>None</li>
+        {% for sn, language in languages %}
+            <li><a href={% url 'exercise:exercise:overview' %}?lang={{ sn }}>{{ language }}
+            </li>
+        {% endfor %}
+    </ul>
+</div>
+
+{% endblock %}
 
 
 
@@ -38,7 +53,7 @@ $(document).ready(function() {
 -->
 {% block content %}
 
-{% cache cache_timeout exercise-overview language.id %}
+{% cache 1 exercise-overview language.id %}
 {% regroup exercises by category as exercise_list %}
 <ul class="nav nav-tabs">
     {% for item in exercise_list %}

--- a/wger/exercises/templates/exercise/overview.html
+++ b/wger/exercises/templates/exercise/overview.html
@@ -8,7 +8,8 @@
 <!--
         Title
 -->
-{% block title %}{% trans "Exercises" %}
+{% block title %}
+{% trans "Exercises" %}
 
 <div class="btn-group" style="float:right;">
     <button type="button" class="btn btn-primary dropdown-toggle btn-xs" data-toggle="dropdown">

--- a/wger/exercises/tests/test_exercise.py
+++ b/wger/exercises/tests/test_exercise.py
@@ -85,8 +85,8 @@ class ExerciseIndexTestCase(WorkoutManagerTestCase):
         self.assertEqual(category_1.name, "Another category")
 
         category_2 = response.context['exercises'][1].category
-        self.assertEqual(category_2.id, 3)
-        self.assertEqual(category_2.name, "Yet another category")
+        self.assertEqual(category_2.id, 2)
+        self.assertEqual(category_2.name, "Another category")
 
         # Correct exercises in the categories
         exercises_1 = category_1.exercise_set.all()

--- a/wger/exercises/views/exercises.py
+++ b/wger/exercises/views/exercises.py
@@ -87,6 +87,7 @@ class ExerciseListView(ListView):
                 language = ln.first().id
         if language:
             return Exercise.objects.accepted() \
+                .filter(language=language) \
                 .order_by('category__id') \
                 .select_related()
 

--- a/wger/exercises/views/exercises.py
+++ b/wger/exercises/views/exercises.py
@@ -41,6 +41,7 @@ from django.views.generic import (
 )
 
 from wger.manager.models import WorkoutLog
+from wger.core.models import Language
 from wger.exercises.models import (
     Exercise,
     Muscle,
@@ -77,9 +78,20 @@ class ExerciseListView(ListView):
         '''
         Filter to only active exercises in the configured languages
         '''
-        languages = load_item_languages(LanguageConfig.SHOW_ITEM_EXERCISES)
+        query_language = self.request.GET.get('lang', None)
+        language = None
+
+        if query_language:
+            ln = Language.objects.filter(short_name=query_language)
+            if ln.exists():
+                language = ln.first().id
+        if language:
+            return Exercise.objects.accepted() \
+                .order_by('category__id') \
+                .select_related()
+
+
         return Exercise.objects.accepted() \
-            .filter(language__in=languages) \
             .order_by('category__id') \
             .select_related()
 

--- a/wger/nutrition/templates/ingredient/overview.html
+++ b/wger/nutrition/templates/ingredient/overview.html
@@ -26,7 +26,23 @@
     </script>
 {% endblock %}
 
-{% block title %}{% trans "Ingredient overview" %}{% endblock %}
+{% block title %}{% trans "Ingredient overview" %}
+
+<div class="btn-group" style="float:right;">
+        <button type="button" class="btn btn-primary dropdown-toggle btn-xs" data-toggle="dropdown">
+            {% trans "Filter by language" %}
+            <span class="caret"></span>
+        </button>
+        <ul class="dropdown-menu" role="menu">
+            {% for sn, language in languages %}
+            <li>
+                <a href={% url 'nutrition:ingredient:list' %}?lang={{ sn }}> {{ language }}</a>
+            </li>
+            {% endfor %}
+        </ul>
+    </div>
+
+{% endblock %}
 
 
 {% block content %}

--- a/wger/nutrition/templates/ingredient/overview.html
+++ b/wger/nutrition/templates/ingredient/overview.html
@@ -26,17 +26,18 @@
     </script>
 {% endblock %}
 
-{% block title %}{% trans "Ingredient overview" %}
+{% block title %}
+{% trans "Ingredient overview" %}
 
 <div class="btn-group" style="float:right;">
-        <button type="button" class="btn btn-primary dropdown-toggle btn-xs" data-toggle="dropdown">
-            {% trans "Filter by language" %}
-            <span class="caret"></span>
-        </button>
-        <ul class="dropdown-menu" role="menu">
+    <button type="button" class="btn btn-primary dropdown-toggle btn-xs" data-toggle="dropdown">
+        {% trans "Filter by language" %}
+        <span class="caret"></span>
+    </button>
+    <ul class="dropdown-menu" role="menu">
             {% for sn, language in languages %}
             <li>
-                <a href={% url 'nutrition:ingredient:list' %}?lang={{ sn }}> {{ language }}</a>
+                <a href={% url 'nutrition:ingredient:list' %}?lang={{ sn }}> {{ language }} </a>
             </li>
             {% endfor %}
         </ul>

--- a/wger/nutrition/views/ingredient.py
+++ b/wger/nutrition/views/ingredient.py
@@ -32,6 +32,7 @@ from django.views.generic import (
 )
 
 from wger.nutrition.forms import UnitChooserForm
+from wger.core.models import Language
 from wger.nutrition.models import Ingredient
 from wger.utils.generic_views import (
     WgerFormMixin,
@@ -64,10 +65,18 @@ class IngredientListView(ListView):
         (the user can also want to see ingredients in English, in addition to his
         native language, see load_ingredient_languages)
         '''
-        languages = load_ingredient_languages(self.request)
-        return (Ingredient.objects.filter(language__in=languages)
-                                  .filter(status__in=Ingredient.INGREDIENT_STATUS_OK)
-                                  .only('id', 'name'))
+
+        query_language = self.request.GET.get('lang', None)
+        language = None
+        if query_language:
+            ln = Language.objects.filter(short_name=query_language)
+            if ln.exists():
+                language = ln.first().id
+        if language:
+            return (Ingredient.objects.filter(language=language).filter(
+                status__in=Ingredient.INGREDIENT_STATUS_OK).only('id', 'name'))
+        return (Ingredient.objects.filter(
+            status__in=Ingredient.INGREDIENT_STATUS_OK).only('id', 'name'))
 
     def get_context_data(self, **kwargs):
         '''

--- a/wger/nutrition/views/ingredient.py
+++ b/wger/nutrition/views/ingredient.py
@@ -73,10 +73,10 @@ class IngredientListView(ListView):
             if ln.exists():
                 language = ln.first().id
         if language:
-            return (Ingredient.objects.filter(language=language).filter(
-                status__in=Ingredient.INGREDIENT_STATUS_OK).only('id', 'name'))
+            return (Ingredient.objects.filter(language=language)
+                    .filter(status__in=Ingredient.INGREDIENT_STATUS_OK).only('id', 'name'))
         return (Ingredient.objects.filter(
-            status__in=Ingredient.INGREDIENT_STATUS_OK).only('id', 'name'))
+                status__in=Ingredient.INGREDIENT_STATUS_OK).only('id', 'name'))
 
     def get_context_data(self, **kwargs):
         '''


### PR DESCRIPTION
### What does this PR do?

- Enables ability to translate the exercises and ingredients into different languages. 

### Description of Task to be completed?

- The user should be able to translate the available exercises and Ingredients to a language of their choosing using a filter button.  

#### How should this be manually tested?

- Log in to the application as an admin, visit the exercise menu on the exercise tab https://ravens-staging.herokuapp.com/en/exercise/overview/
- Click on the _[Filter by language](https://ravens-staging.herokuapp.com/en/exercise/overview/)_ drop down menu and chose your preferred language from the drop down.  
- The available exercises and Ingredients should then be translated to correspond to the chosen language. 

### Any background context you want to provide?

- Initially, the exercises and ingredients were available only in one language.

### What are the relevant pivotal tracker stories?

#157589646

<img width="847" alt="filter by language" src="https://user-images.githubusercontent.com/6715848/41280548-dcf8b760-6e37-11e8-9fb4-a1617380ffb1.png">
