### PR TITLE
#157589648 Enable Member Data Comparison

### DIFF
--- a/wger/core/templates/comparison.html
+++ b/wger/core/templates/comparison.html
@@ -1,0 +1,82 @@
+{% extends "base_wide.html" %} {% load i18n staticfiles wger_extras %} {% block title %}{% trans "Weight Comparison" %}{% endblock%}
+{% block header %}
+<script src="{% static 'js/user.js' %}"></script>
+{% endblock %} {% block content %}
+
+<div id="current-username" data-current-username="{{ owner_user.username }}" value="{{ owner_user.username }}"></div>
+
+<div class="row">
+
+    <div class="col-md-6">
+        My Graph
+        {% if not min_date %}
+        <p>
+            {% trans "There is no chart here because there are no weight entries." %}
+        </p>
+        {% endif %}
+        <div id="user_diagram"></div>
+    </div>
+
+    <div class="col-md-6">
+        <select id="user-change" onchange="userchange(this.value)">
+            <option value="none">--------</option>
+            {% for user in others %}
+            <option value="{{user}}">{{ user }} </option>
+            {% endfor %}
+        </select>
+        <p id="nope">There is no chart here because there are no weight entries.</p>
+        <div id="others_diagram"></div>
+
+
+
+    </div>
+</div>
+<script>
+  function userchange(username) {
+  var url;
+  var chartParams;
+  var weightChart;
+  weightChart = {};
+  chartParams = {
+    animate_on_load: true,
+    full_width: true,
+    top: 10,
+    left: 30,
+    right: 10,
+    show_secondary_x_label: true,
+    xax_count: 10,
+    target: '#others_diagram',
+    x_accessor: 'date',
+    y_accessor: 'weight',
+    min_y_from_data: true,
+    colors: ['#3465a4']
+  };
+  url = '/weight/api/get_user_weight_data/' + username;
+  d3.json(url, function (json) {
+    var data;
+    if (json.length) {
+      $('#others_diagram').show();
+      data = MG.convert.date(json, 'date');
+      weightChart.data = data;
+      // Plot the data
+      chartParams.data = data;
+      MG.data_graphic(chartParams);
+      $('#nope').hide();
+    } else {
+      $('#nope').show();
+      $('#others_diagram').hide();
+    }
+  });
+  $('.modify-time-period-controls button').click(function () {
+    var pastNumberDays = $(this).data('time_period');
+    var data = modifyTimePeriod(weightChart.data, pastNumberDays);
+    // change button state
+    $(this).addClass('active').siblings().removeClass('active');
+    if (data.length) {
+      chartParams.data = data;
+      MG.data_graphic(chartParams);
+    }
+  });
+}
+</script>
+{% endblock %}

--- a/wger/core/templates/navigation.html
+++ b/wger/core/templates/navigation.html
@@ -152,6 +152,19 @@
                         </li>
 
                         {#                     #}
+                        {# comparison graphs   #}
+                        {#                     #}
+                        <li {% if active_tab == 'user' %}class="active"{% endif %}>
+                            <a href="{% url 'core:comparison'%}">
+                                {% if not user.is_authenticated %}
+                                {% trans "Features" %}
+                                {% else %}
+                                {% trans "Comparison" %}
+                                {% endif %}
+                            </a>
+                        </li>
+
+                        {#                     #}
                         {# Options and contact #}
                         {#                     #}
                         <li class="dropdown visible-xs-block visible-sm-block">

--- a/wger/core/templates/template.html
+++ b/wger/core/templates/template.html
@@ -64,7 +64,12 @@
     <script src="{% static 'bower_components/jquery/dist/jquery.js' %}"></script>
     <script src="{% static 'bower_components/bootstrap/dist/js/bootstrap.min.js' %}"></script>
     <script src="{% static 'bower_components/Sortable/Sortable.min.js' %}"></script>
-    <script src="{% static 'bower_components/d3/d3.js' %}"></script>
+
+    <!--<script src="{% static 'https://cdnjs.cloudflare.com/ajax/libs/d3/4.13.0/d3.min.js' %}"></script>-->
+
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/d3/4.13.0/d3.min.js"></script>
+
+
     <script src="{% static 'bower_components/metrics-graphics/dist/metricsgraphics.min.js' %}"></script>
     <script src="{% static 'bower_components/devbridge-autocomplete/dist/jquery.autocomplete.min.js' %}"></script>
     <script src="{% static 'js/wger-core.js' %}"></script>

--- a/wger/core/urls.py
+++ b/wger/core/urls.py
@@ -123,6 +123,10 @@ urlpatterns = [
         template_name="misc/contact.html"), name='contact'),
     url(r'^feedback$', misc.FeedbackClass.as_view(), name='feedback'),
 
+    #comparison
+    url(r'^comparison$', misc.comparison, name='comparison'),
+
+
     url(r'^language/', include(patterns_language, namespace="language")),
     url(r'^user/', include(patterns_user, namespace="user")),
     url(r'^license/', include(patterns_license, namespace="license")),

--- a/wger/core/views/misc.py
+++ b/wger/core/views/misc.py
@@ -29,6 +29,9 @@ from django.contrib import messages
 from django.contrib.auth.decorators import login_required
 from django.contrib.auth import login as django_login
 from django.template.loader import render_to_string
+from django.contrib.auth.models import User
+from django.db.models import Min
+from django.db.models import Max
 
 
 from wger.core.forms import FeedbackRegisteredForm, FeedbackAnonymousForm
@@ -38,6 +41,11 @@ from wger.manager.models import Schedule
 from wger.nutrition.models import NutritionPlan
 from wger.weight.models import WeightEntry
 from wger.weight.helpers import get_last_entries
+from wger.weight import helpers
+from wger.utils.helpers import check_access
+
+
+
 
 
 logger = logging.getLogger(__name__)
@@ -79,6 +87,45 @@ def demo_entries(request):
                                     'better see what  this site can do. Feel free to edit or '
                                     'delete them!'))
     return HttpResponseRedirect(reverse('core:dashboard'))
+
+def comparison(request, username=None):
+    '''
+    Analysis view
+    '''
+    users = list(User.objects.all())
+
+    is_owner, user = check_access(request.user, username)
+    others = User.objects.exclude(username=user.username)
+
+    template_data = {}
+
+    min_date = WeightEntry.objects.filter(user=user).aggregate(Min('date'))['date__min']
+    max_date = WeightEntry.objects.filter(user=user).\
+        aggregate(Max('date'))['date__max']
+
+    if min_date:
+        template_data['min_date'] = 'new Date(%(year)s, %(month)s, %(day)s)' %\
+                {'year': min_date.year,
+                 'month': min_date.month,
+                 'day': min_date.day}
+    if max_date:
+        template_data['max_date'] = 'new Date(%(year)s, %(month)s, %(day)s)' %\
+                {'year': max_date.year,
+                 'month': max_date.month,
+                 'day': max_date.day}
+
+    last_weight_entries = helpers.get_last_entries(user)
+
+    template_data['users'] = users
+    template_data['others'] = others
+    template_data['is_owner'] = is_owner
+    template_data['owner_user'] = user
+    template_data['show_shariff'] = is_owner
+    template_data['last_five_weight_entries_details'] = last_weight_entries
+
+    if request.user.is_authenticated():
+        return render(request, 'comparison.html', template_data)
+    return render(request, 'index.html')
 
 
 @login_required

--- a/wger/utils/month_range.py
+++ b/wger/utils/month_range.py
@@ -1,0 +1,24 @@
+'''return the range of days for the current month'''
+from datetime import date, timedelta
+import calendar
+
+
+def get_month_range(start_date=None):
+    '''calculate the month range'''
+    if start_date is None:
+        start_date = date.today().replace(day=1)
+    month_range = calendar.monthrange(start_date.year, start_date.month)
+    end_date = start_date + timedelta(days=month_range[1]-1)
+    return (start_date, end_date)
+'''return the range of days for the current month'''
+from datetime import date, timedelta
+import calendar
+
+
+def get_month_range(start_date=None):
+    '''calculate the month range'''
+    if start_date is None:
+        start_date = date.today().replace(day=1)
+    month_range = calendar.monthrange(start_date.year, start_date.month)
+    end_date = start_date + timedelta(days=month_range[1]-1)
+    return (start_date, end_date)

--- a/wger/weight/static/js/user.js
+++ b/wger/weight/static/js/user.js
@@ -1,0 +1,78 @@
+/*
+ This file is part of wger Workout Manager.
+ wger Workout Manager is free software: you can redistribute it and/or modify
+ it under the terms of the GNU Affero General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+ wger Workout Manager is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+ You should have received a copy of the GNU Affero General Public License
+ */
+'use strict';
+
+function modifyTimePeriod(data, pastNumberDays) {
+  var filtered;
+  var date;
+  if (data.length) {
+    if (pastNumberDays !== 'all') {
+      date = new Date();
+      date.setDate(date.getDate() - pastNumberDays);
+      filtered = MG.clone(data).filter(function (value) {
+        return value.date >= date;
+      });
+      return filtered;
+    }
+  }
+  return data;
+}
+
+$(document).ready(function () {
+  var url;
+  var username;
+  var chartParams;
+  var weightChart;
+  weightChart = {};
+  chartParams = {
+    animate_on_load: true,
+    full_width: true,
+    top: 10,
+    left: 30,
+    right: 10,
+    show_secondary_x_label: true,
+    xax_count: 10,
+    target: '#user_diagram',
+    x_accessor: 'date',
+    y_accessor: 'weight',
+    min_y_from_data: true,
+    colors: ['#3465a4']
+  };
+
+  username = $('#current-username').data('currentUsername');
+  url = '/weight/api/get_logged_user_weight_data/' + username;
+
+  d3.json(url, function (json) {
+    var data;
+    if (json.length) {
+      data = MG.convert.date(json, 'date');
+      weightChart.data = data;
+
+      // Plot the data
+      chartParams.data = data;
+      MG.data_graphic(chartParams);
+    }
+  });
+
+  $('.modify-time-period-controls button').click(function () {
+    var pastNumberDays = $(this).data('time_period');
+    var data = modifyTimePeriod(weightChart.data, pastNumberDays);
+
+    // change button state
+    $(this).addClass('active').siblings().removeClass('active');
+    if (data.length) {
+      chartParams.data = data;
+      MG.data_graphic(chartParams);
+    }
+  });
+});

--- a/wger/weight/urls.py
+++ b/wger/weight/urls.py
@@ -50,4 +50,13 @@ urlpatterns = [
     url(r'^api/get_weight_data/$', # JS
         views.get_weight_data,
         name='weight-data'),
+
+    url(r'^api/get_logged_user_weight_data/(?P<username>[\w.@+-]+)$', # JS
+        views.get_logged_user_weight_data,
+        name='logged_user_weight-data',
+       ),
+    url(r'^api/get_user_weight_data/(?P<username>[\w.@+-]+)$', # JS
+        views.get_user_weight_data,
+        name='user_weight-data',
+       ),
 ]

--- a/wger/weight/views.py
+++ b/wger/weight/views.py
@@ -31,6 +31,8 @@ from django.db.models import Min
 from django.db.models import Max
 from django.views.generic import CreateView
 from django.views.generic import UpdateView
+from django.contrib.auth.models import User
+from wger.utils.month_range import get_month_range
 
 from rest_framework.response import Response
 from rest_framework.decorators import api_view
@@ -161,7 +163,7 @@ def overview(request, username=None):
     return render(request, 'overview.html', template_data)
 
 
-@api_view(['GET'])
+
 def get_weight_data(request, username=None):
     '''
     Process the data to pass it to the JS libraries to generate an SVG image
@@ -183,6 +185,45 @@ def get_weight_data(request, username=None):
     for i in weights:
         chart_data.append({'date': i.date,
                            'weight': i.weight})
+
+    # Return the results to the client
+    return Response(chart_data)
+
+@api_view(['GET'])
+def get_logged_user_weight_data(request, username=None):
+    '''
+      Process the user data and pass it to the JS libraries to generate a SVG image
+    '''
+    is_owner, user = check_access(request.user, username)
+    date_min_max = get_month_range()
+
+    if date_min_max:
+        weights = WeightEntry.objects.filter(user=user, date__range=date_min_max)
+    else:
+        weights = WeightEntry.objects.filter(user=user)
+
+    chart_data = []
+
+    for i in weights:
+        chart_data.append({'date': i.date, 'weight': i.weight})
+
+    # Return the results to the client
+    return Response(chart_data)
+
+
+@api_view(['GET'])
+def get_user_weight_data(request, username=None):
+    '''
+      Process the user data and pass it to the JS libraries to generate a SVG image
+    '''
+    user = User.objects.filter(username=username)
+    date_min_max = get_month_range()
+    weights = WeightEntry.objects.filter(user=user, date__range=date_min_max)
+
+    chart_data = []
+
+    for i in weights:
+        chart_data.append({'date': i.date, 'weight': i.weight})
 
     # Return the results to the client
     return Response(chart_data)


### PR DESCRIPTION
### What does this PR do?

- Shows Comparison of member data.

### Description of Task to be completed?

- When two users are training together it would be useful to see a comparison of some sorts. A possibility would be to have a graph where the data for (selected) members is shown or, less nicely, at least have different graphs under each other.

#### How should this be manually tested?

- Log in to the application as an admin or a user, visit the comparison tab on https://ravens-staging.herokuapp.com/en/comparison
- Your graph will be populated on the left. Select a gym member to compare with from the drop down available on the right.
- A graph for the selected gym member should be populated on the right.

### Any background context you want to provide?

- Initially, users were unable to compare gym data with other gym members

### What are the relevant pivotal tracker stories?

#157589648

<img width="1275" alt="weight comparison" src="https://user-images.githubusercontent.com/6715848/41531429-fc140d66-72fb-11e8-9fda-f91ca8638c74.png">

